### PR TITLE
Fix JSXElement Types

### DIFF
--- a/jsx-runtime.ts
+++ b/jsx-runtime.ts
@@ -6,10 +6,12 @@ export type Element = hast.Element;
 
 export type JSXChild = string | number | boolean | JSXElement;
 
+export type JSXChildren = JSXChild | JSXChild[];
+
 export type JSXElement = hast.Element | hast.Root | hast.Text;
 
 export type JSXElementProps = Record<string, string> & {
-  children?: JSXChild | JSXChild[];
+  children?: JSXChildren;
 };
 export type JSXComponentProps = Record<string, unknown> & {
   key?: string;
@@ -25,7 +27,7 @@ export interface JSXElementConstructor {
 }
 
 declare global {
-  namespace JSX {
+  export namespace JSX {
     type Element = JSXElement;
     type ElementType =
       | keyof html.HTMLElements

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,1 @@
+export type { JSXChildren, JSXElement } from "./jsx-runtime.ts";


### PR DESCRIPTION
## Motivation

section and other HTML elements were not getting typed correctly

## Approach

Make sure that JSXElement type is exported from the global module
