### PR TITLE
Add missing github registry url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
+          registry-url: https://registry.npmjs.org/
           node-version: 18.x
 
       - name: Build


### PR DESCRIPTION
## Motivation

Publish step was failing due to ENEEDAUTH error

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
npm error need auth You need to authorize this machine using `npm adduser`
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-02-08T00_34_06_419Z-debug-0.log
Error: Process completed with exit code 1.
```


## Approach

It turns out that `setup-node@v4` doesn't setup unless you provide a registry url.

```
# Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, 
# and set up auth to read in from env.NODE_AUTH_TOKEN.
# Default: ''
registry-url: ''
```
