### PR TITLE
jsx-dev-runtime: Re-export from jsx-runtime

### DIFF
--- a/jsx-dev-runtime.ts
+++ b/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from "./jsx-runtime.ts";

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -20,6 +20,10 @@ await build({
       path: "./jsx-runtime.ts",
     },
     {
+      name: "./jsx-dev-runtime",
+      path: "./jsx-dev-runtime.ts",
+    },
+    {
       name: "./html",
       path: "./html.ts",
     },


### PR DESCRIPTION
Depending on NODE_ENV and other factors, Bun may choose to import `hastx/jsx-dev-runtime` instead of `hastx/jsx-runtime`.

https://github.com/oven-sh/bun/blob/9d2eb78544331f7e32d77d9f2ddd239771de82e9/src/options.zig#L1223-L1234

Tested against Bun 1.3.1 x86_64-linux