### PR TITLE
Generate correct output for `<template>`

### DIFF
--- a/jsx-runtime.ts
+++ b/jsx-runtime.ts
@@ -63,12 +63,25 @@ export function jsx(
     let { children, ...properties } = props as JSXElementProps;
     let className = properties.class ? { className: properties.class } : null;
 
-    return {
-      type: "element",
-      tagName,
-      properties: { ...properties, ...className },
-      children: read(children).filter((child) => child.type !== "doctype"),
-    };
+    if (tagName === "template") {
+      return {
+        type: "element",
+        tagName,
+        properties: { ...properties, ...className },
+        children: [],
+        content: {
+          type: "root",
+          children: read(children),
+        },
+      };
+    } else {
+      return {
+        type: "element",
+        tagName,
+        properties: { ...properties, ...className },
+        children: read(children).filter((child) => child.type !== "doctype"),
+      };
+    }
   } else {
     return {
       type: "root",

--- a/test/jsx.test.tsx
+++ b/test/jsx.test.tsx
@@ -137,10 +137,15 @@ describe("JSX runtime", () => {
     expect(el.properties.className).toEqual("button");
   });
 
+  it("supports <template>", () => {
+    expect(<template>foo</template>).toEqual(h("template", "foo"));
+  });
+
   it("strips <!DOCTYPE> from element children", () => {
     const root: JSXChild = { type: "root", children: [{ type: "doctype" }] };
     expect(<>{root}</>).toEqual(root);
     expect(<div>{root}</div>).toEqual(h("div"));
+    expect(<template>{root}</template>).toEqual(h("template", root));
   });
 
   it("allows components returning primitives or arrays", () => {


### PR DESCRIPTION
https://github.com/syntax-tree/hast/blob/2.4.0/readme.md?plain=1#L134-L138